### PR TITLE
Add theme styling option for colors and labels

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -13,4 +13,9 @@
   .ocb--danger{color:var(--ocb-danger-text,#ffcdd2)}
 }
 
+/* Theme integration: when enabled, let the site theme control colors and label style */
+.ocb.ocb--theme{border-color:currentColor;background:transparent}
+.ocb.ocb--theme.ocb--warn,.ocb.ocb--theme.ocb--danger{color:inherit}
+.ocb.ocb--theme .ocb-label{font:inherit;color:inherit}
+
 


### PR DESCRIPTION
Add an option to use theme styling for the outdated content notice to allow themes to control its colors and label style.

---
<a href="https://cursor.com/background-agent?bcId=bc-c65fab9e-1bf8-4c35-b158-dc23b7664aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c65fab9e-1bf8-4c35-b158-dc23b7664aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

