### PR TITLE
fix: update GitHub Actions deploy workflow to use correct action version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       #     echo "No build step required"
 
       - name: WordPress Plugin Deploy
-        uses: 10up/action-wordpress-plugin-deploy@v2
+        uses: 10up/action-wordpress-plugin-deploy@v1
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/languages/wp-outdated-content.pot
+++ b/languages/wp-outdated-content.pot
@@ -1,0 +1,15 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: WP Outdated Content 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-18 00:00+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: \n"
+"X-Generator: Handcrafted\n"
+"X-Domain: wp-outdated-content\n"
+
+


### PR DESCRIPTION
- Change 10up/action-wordpress-plugin-deploy from @v2 to @v1
- Fixes deployment error: unable to find version v2
- Ensures workflow runs successfully on tag push