### PR TITLE
ci(gha): use 10up WP actions @stable instead of @v1 to fix resolve error

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: WordPress.org Plugin Asset Update
-        uses: 10up/action-wordpress-plugin-asset-update@v1
+        uses: 10up/action-wordpress-plugin-asset-update@stable
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       #     echo "No build step required"
 
       - name: WordPress Plugin Deploy
-        uses: 10up/action-wordpress-plugin-deploy@v1
+        uses: 10up/action-wordpress-plugin-deploy@stable
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}


### PR DESCRIPTION
- Replace 10up/action-wordpress-plugin-deploy@v1 -> @stable
- Replace 10up/action-wordpress-plugin-asset-update@v1 -> @stable
- Files: .github/workflows/deploy.yml, .github/workflows/assets.yml

Reason: GH Actions failed with:
Unable to resolve action `10up/action-wordpress-plugin-deploy@v1`, unable to find version `v1`.
