### PR TITLE
Fix WordPress Plugin Review: Add Contributor and Version Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,6 @@ Copyright (c) 2025 Adiscon GmbH
 
 ## Changelog
 
+- v1.0.2 -- Add alorbach to Contributors list
 - v1.0.1 -- Add age basis setting (default: modified); use selected basis for age and displayed date; enable WP color picker for color settings
 - v1.0.0 -- Initial release

--- a/adiscon-outdated-content.php
+++ b/adiscon-outdated-content.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Adiscon Outdated Content
  * Description:       Adds an accessible, configurable notice to outdated posts/pages with thresholds, labels, and colors.
- * Version:           1.0.1
+ * Version:           1.0.2
  * Author:            Adiscon GmbH
  * Text Domain:       adiscon-outdated-content
  * Domain Path:       /languages
@@ -23,7 +23,7 @@ if ( ! class_exists( 'Adiscon_Outdated_Content' ) ) {
     final class Adiscon_Outdated_Content {
         private static $instance = null;
 
-        const VERSION    = '1.0.1';
+        const VERSION    = '1.0.2';
         const OPTION_KEY = 'adiscon_outdated_content';
         const OPTION_KEY_OLD = 'adiscon_outdated_content_old';
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === Adiscon Outdated Content ===
-Contributors: adiscon
+Contributors: adiscon, alorbach
 Tags: outdated, last updated, content age, notice, json-ld
 Requires at least: 6.0
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -83,6 +83,9 @@ Yes. Built-in styles adapt via prefers-color-scheme. You can also set separate t
 3. JSON-LD markup example (structured data)
 
 == Changelog ==
+
+= 1.0.2 =
+- Add alorbach to Contributors list
 
 = 1.0.1 =
 - Add age basis setting (default: modified); use selected basis for age and displayed date


### PR DESCRIPTION
This PR addresses the WordPress plugin review feedback by adding the missing contributor and updating the plugin version.

Changes:
- Add 'alorbach' to Contributors list in readme.txt
- Update version from 1.0.1 to 1.0.2 across all files
- Add changelog entries for version 1.0.2
- Create AGENTS.md documentation for future version updates

Files modified:
- readme.txt: Updated Contributors and Stable tag, added changelog
- adiscon-outdated-content.php: Updated version in header and constant
- README.md: Added changelog entry
- AGENTS.md: New file with version update instructions and agent keywords

This resolves the WordPress plugin review issue and prepares the plugin for resubmission.